### PR TITLE
Security config for /v2/onset (incl. tests)

### DIFF
--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
@@ -36,7 +36,7 @@ public class AuthCodeVerificationControllerV2 {
         log.debug("Call of Verify with authCode '{}'.", verificationDto.getAuthorizationCode());
         final AuthorizationCodeVerifyResponseDtoWrapper accessTokenWrapper = authCodeVerificationService.verify(verificationDto.getAuthorizationCode(), verificationDto.getFake(), true);
         normalizeRequestTime(now);
-        if (accessTokenWrapper.getDP3TAccessToken() == null || accessTokenWrapper.getCheckInAccessToken() == null) {
+        if (accessTokenWrapper == null || accessTokenWrapper.getDP3TAccessToken() == null || accessTokenWrapper.getCheckInAccessToken() == null) {
             throw new ResourceNotFoundException(null);
         }
         return ResponseEntity.ok().body(accessTokenWrapper);

--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/security/HttpResponseHeaderFilter.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/security/HttpResponseHeaderFilter.java
@@ -5,7 +5,7 @@ import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-@WebFilter(urlPatterns = {"/v1/onset/*", "/v1/authcode/*"})
+@WebFilter(urlPatterns = {"/v1/onset/*", "/v2/onset/*", "/v1/authcode/*"})
 public class HttpResponseHeaderFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response,

--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/security/WebSecurityConfig.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/security/WebSecurityConfig.java
@@ -29,11 +29,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.requestMatchers().
-                antMatchers("/actuator/**", "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/v1/onset/**").
+                antMatchers("/actuator/**", "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/v1/onset/**", "/v2/onset/**").
                 and().
                 authorizeRequests().anyRequest().permitAll();
 
-        http.csrf().ignoringAntMatchers("/v1/onset/**");
+        http.csrf().ignoringAntMatchers("/v1/onset/**", "/v2/onset/**");
     }
 
     @Bean

--- a/src/test/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2SecurityTest.java
+++ b/src/test/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2SecurityTest.java
@@ -1,0 +1,83 @@
+package ch.admin.bag.covidcode.authcodegeneration.web.controller;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.admin.bag.covidcode.authcodegeneration.api.AuthorizationCodeVerificationDto;
+import ch.admin.bag.covidcode.authcodegeneration.api.AuthorizationCodeVerifyResponseDto;
+import ch.admin.bag.covidcode.authcodegeneration.api.AuthorizationCodeVerifyResponseDtoWrapper;
+import ch.admin.bag.covidcode.authcodegeneration.config.security.OAuth2SecuredWebConfiguration;
+import ch.admin.bag.covidcode.authcodegeneration.service.AuthCodeVerificationService;
+import ch.admin.bag.covidcode.authcodegeneration.testutil.LocalDateSerializer;
+import ch.admin.bag.covidcode.authcodegeneration.web.security.WebSecurityConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(value = {AuthCodeVerificationControllerV2.class, OAuth2SecuredWebConfiguration.class, WebSecurityConfig.class})
+@ActiveProfiles("local")
+class AuthCodeVerificationControllerV2SecurityTest {
+
+    private static final String URL = "/v2/onset";
+    private static final String TEST_AUTHORIZATION_CODE = "123456789";
+    private static final String FAKE = "0";
+    private static final String DUMMY_FOO = "foo";
+    private static final String DUMMY_BAR = "bar";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthCodeVerificationService service;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeAll
+    static void setup() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(LocalDate.class, new LocalDateSerializer());
+        MAPPER.registerModule(module);
+    }
+
+    @Test
+    void test_verify_authorization_without_token_is_permitted() throws Exception {
+        AuthorizationCodeVerificationDto verificationDto = new AuthorizationCodeVerificationDto(TEST_AUTHORIZATION_CODE, FAKE);
+        AuthorizationCodeVerifyResponseDto dp3tResponseDto = new AuthorizationCodeVerifyResponseDto(DUMMY_FOO);
+        AuthorizationCodeVerifyResponseDto checkInResponseDto = new AuthorizationCodeVerifyResponseDto(DUMMY_BAR);
+        final var expectedWrapper = new AuthorizationCodeVerifyResponseDtoWrapper(dp3tResponseDto, checkInResponseDto);
+        when(service.verify(anyString(), anyString(), anyBoolean())).thenReturn(expectedWrapper);
+
+        mockMvc.perform(post(URL)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(MAPPER.writeValueAsString(verificationDto)))
+                .andExpect(status().isOk());
+
+        verify(service, times(1)).verify(anyString(), anyString(), anyBoolean());
+    }
+
+    @Test
+    void test_verify_authorization_without_token_is_permitted_return_404() throws Exception {
+        AuthorizationCodeVerificationDto verificationDto = new AuthorizationCodeVerificationDto(TEST_AUTHORIZATION_CODE, FAKE);
+        mockMvc.perform(post(URL)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(MAPPER.writeValueAsString(verificationDto)))
+                .andExpect(status().is(404));
+
+        verify(service, times(1)).verify(anyString(), anyString(), anyBoolean());
+    }
+}


### PR DESCRIPTION
This PR add tests for `AuthCodeVerificationControllerV2` that go through security filters and then adjusts the `WebSecurityConfig` to contain `/v2/onset`. 