### PR TITLE
getOnset request

### DIFF
--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/api/AuthorizationCodeOnsetResponseDto.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/api/AuthorizationCodeOnsetResponseDto.java
@@ -1,0 +1,15 @@
+package ch.admin.bag.covidcode.authcodegeneration.api;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthorizationCodeOnsetResponseDto {
+
+    private String onset;
+
+}

--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
@@ -1,5 +1,6 @@
 package ch.admin.bag.covidcode.authcodegeneration.web.controller;
 
+import ch.admin.bag.covidcode.authcodegeneration.api.AuthorizationCodeOnsetResponseDto;
 import ch.admin.bag.covidcode.authcodegeneration.api.AuthorizationCodeVerificationDto;
 import ch.admin.bag.covidcode.authcodegeneration.api.AuthorizationCodeVerifyResponseDto;
 import ch.admin.bag.covidcode.authcodegeneration.api.AuthorizationCodeVerifyResponseDtoWrapper;
@@ -40,6 +41,13 @@ public class AuthCodeVerificationControllerV2 {
             throw new ResourceNotFoundException(null);
         }
         return ResponseEntity.ok().body(accessTokenWrapper);
+    }
+
+    @Operation(summary = "Get onset date for authorization code")
+    @PostMapping(value="/date")
+    public AuthorizationCodeOnsetResponseDto getOnset(@Valid @RequestBody AuthorizationCodeVerificationDto verificationDto) {
+        // TODO: Return JSON Object containing onset as String
+        return null;
     }
 
     private void normalizeRequestTime(long now) {

--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
@@ -45,9 +45,17 @@ public class AuthCodeVerificationControllerV2 {
 
     @Operation(summary = "Get onset date for authorization code")
     @PostMapping(value="/date")
-    public AuthorizationCodeOnsetResponseDto getOnset(@Valid @RequestBody AuthorizationCodeVerificationDto verificationDto) {
-        // TODO: Return JSON Object containing onset as String
-        return null;
+    public ResponseEntity<AuthorizationCodeOnsetResponseDto> getOnset(@Valid @RequestBody AuthorizationCodeVerificationDto verificationDto) {
+        var now = Instant.now().toEpochMilli();
+        log.debug("Call of getOnset with authCode '{}'.", verificationDto.getAuthorizationCode());
+        final AuthorizationCodeOnsetResponseDto onsetWrapper =
+            authCodeVerificationService.getOnsetForAuthCode(
+                verificationDto.getAuthorizationCode(), verificationDto.getFake());
+        if (onsetWrapper == null || onsetWrapper.getOnset() == null) {
+            throw new ResourceNotFoundException(null);
+        }
+        // TODO: Normalize request time?
+        return ResponseEntity.ok().body(onsetWrapper);
     }
 
     private void normalizeRequestTime(long now) {

--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
@@ -54,7 +54,7 @@ public class AuthCodeVerificationControllerV2 {
         if (onsetWrapper == null || onsetWrapper.getOnset() == null) {
             throw new ResourceNotFoundException(null);
         }
-        // TODO: Normalize request time?
+        normalizeRequestTime(now);
         return ResponseEntity.ok().body(onsetWrapper);
     }
 

--- a/src/test/java/ch/admin/bag/covidcode/authcodegeneration/service/AuthCodeVerificationServiceTest.java
+++ b/src/test/java/ch/admin/bag/covidcode/authcodegeneration/service/AuthCodeVerificationServiceTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Optional;
 
@@ -152,6 +153,55 @@ class AuthCodeVerificationServiceTest {
         //when
         //then
         assertNull(testee.verify(TEST_AUTHORIZATION_CODE, FAKE_NOT_FAKE));
+    }
+
+    @Test
+    void test_getOnset() {
+        //given
+        final var onsetAsDate = LocalDate.now().minusDays(3);
+        final var onsetAsString = onsetAsDate.format(DateTimeFormatter.ofPattern("YYYY-MM-dd"));
+        AuthorizationCode authCode = new AuthorizationCode(TEST_AUTHORIZATION_CODE, LocalDate.now(), onsetAsDate, ZonedDateTime.now().plusSeconds(CODE_EXPIRATION_DELAY_IN_SECONDS));
+        ReflectionTestUtils.setField(testee, CALL_COUNT_LIMIT_KEY, CALL_COUNT_LIMIT);
+        when(repository.findByCode(anyString())).thenReturn(Optional.of(authCode));
+        //when
+        String onset = testee.getOnsetForAuthCode(TEST_AUTHORIZATION_CODE, FAKE_NOT_FAKE).getOnset();
+        //then
+        assertNotNull(onset);
+        assertEquals(onsetAsString, onset);
+    }
+
+    @Test
+    void test_getOnset_code_not_found() {
+        //given
+        when(repository.findByCode(anyString())).thenReturn(Optional.empty());
+        //when
+        //then
+        assertNull(testee.getOnsetForAuthCode(TEST_AUTHORIZATION_CODE, FAKE_NOT_FAKE).getOnset());
+    }
+
+    @Test
+    void test_getOnset_code_validy_expired() {
+        //given
+        AuthorizationCode authCode = new AuthorizationCode(TEST_AUTHORIZATION_CODE, LocalDate.now(), LocalDate.now().minusDays(3), ZonedDateTime.now());
+        when(repository.findByCode(anyString())).thenReturn(Optional.of(authCode));
+        //when
+        //then
+        assertNull(testee.getOnsetForAuthCode(TEST_AUTHORIZATION_CODE, FAKE_NOT_FAKE).getOnset());
+    }
+
+    @Test
+    void test_getOnset_code_call_count_reached() {
+        //given
+        AuthorizationCode authCode = new AuthorizationCode(TEST_AUTHORIZATION_CODE, LocalDate.now(), LocalDate.now().minusDays(3), ZonedDateTime.now().plusSeconds(CODE_EXPIRATION_DELAY_IN_SECONDS));
+        ReflectionTestUtils.setField(testee, CALL_COUNT_LIMIT_KEY, CALL_COUNT_LIMIT);
+        when(repository.findByCode(anyString())).thenReturn(Optional.of(authCode));
+        when(tokenProvider.createToken(anyString(), anyString(), any())).thenReturn(TEST_ACCESS_TOKEN);
+        //when
+        testee.verify(TEST_AUTHORIZATION_CODE, FAKE_NOT_FAKE);
+        testee.verify(TEST_AUTHORIZATION_CODE, FAKE_NOT_FAKE);
+        testee.verify(TEST_AUTHORIZATION_CODE, FAKE_NOT_FAKE);
+        //then
+        assertNull(testee.getOnsetForAuthCode(TEST_AUTHORIZATION_CODE, FAKE_NOT_FAKE).getOnset());
     }
 
 }


### PR DESCRIPTION
Under `/v2/onset/date` one can now obtain the onset date of a given authorization code. Fake requests are allowed and simply return some random onset date. Note that request times are normalized, similar to the verification request.

The core logic is implemented in `AuthCodeVerificationService` in the `getOnset` method.
The method returns the onset date of the given auth code, with the possibility of returning the onset date of a fake token.
Note that the onset string is null if the auth code wasn't found, has expired, or reached its call limit, which results in the request returning 404.
The call count is NOT incremented.