### PR TITLE
Small modification to v2/onset/date endpoint

### DIFF
--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/web/controller/AuthCodeVerificationControllerV2.java
@@ -51,10 +51,10 @@ public class AuthCodeVerificationControllerV2 {
         final AuthorizationCodeOnsetResponseDto onsetWrapper =
             authCodeVerificationService.getOnsetForAuthCode(
                 verificationDto.getAuthorizationCode(), verificationDto.getFake());
+        normalizeRequestTime(now);
         if (onsetWrapper == null || onsetWrapper.getOnset() == null) {
             throw new ResourceNotFoundException(null);
         }
-        normalizeRequestTime(now);
         return ResponseEntity.ok().body(onsetWrapper);
     }
 


### PR DESCRIPTION
Moved call to `normalizeRequestTime` to ensure request time is normalized in exceptional cases, too.
See resolved comment at [https://github.com/admin-ch/CovidCode-Service/pull/38](https://github.com/admin-ch/CovidCode-Service/pull/38).