### PR TITLE
Fix formater. yyyy is correct.

### DIFF
--- a/src/main/java/ch/admin/bag/covidcode/authcodegeneration/service/AuthCodeVerificationService.java
+++ b/src/main/java/ch/admin/bag/covidcode/authcodegeneration/service/AuthCodeVerificationService.java
@@ -28,7 +28,7 @@ import static net.logstash.logback.argument.StructuredArguments.kv;
 public class AuthCodeVerificationService {
 
   private static final String FAKE_STRING = "1";
-  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("YYYY-MM-dd");
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
   private final AuthorizationCodeRepository authorizationCodeRepository;
   private final CustomTokenProvider tokenProvider;
 


### PR DESCRIPTION
Bugfix for onset dateformater. yyyy is year. (YYYY is weakbased year and wrong in that case)